### PR TITLE
Fix for treesitter test in GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,12 @@ jobs:
           sudo apt update -y
           sudo apt install build-essential -y
       - name: Debugging environment
+        if: always()
         run: |
           ls ~/.local/share/nvim
       - name: Run Tests
         run: make test
+      - name: Debugging environment
+        if: always()
+        run: |
+          ls ~/.local/share/nvim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,11 @@ jobs:
         if: always()
         run: |
           ls ~/.local/share/nvim
+          find ~/.local/share/nvim -type d | grep mason
       - name: Run Tests
         run: make test
       - name: Debugging environment
         if: always()
         run: |
           ls ~/.local/share/nvim
+          find ~/.local/share/nvim -type d | grep mason

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,26 @@ jobs:
           git clone --depth 1 https://github.com/hrsh7th/cmp-nvim-lsp.git ~/.local/share/nvim/site/pack/vendor/start/cmp-nvim-lsp.git
           git submodule update --init
           sudo apt update -y
-          sudo apt install build-essential -y
+          sudo apt install build-essential php php-xml php-mbstring php-curl composer -y
       - name: Debugging environment
         if: always()
         run: |
           ls ~/.local/share/nvim
           find ~/.local/share/nvim -type d | grep mason
+      - name: Prepare Mason
+        run: |
+          mkdir -p ~/.local/share/nvim/mason
+          mkdir -p ~/.local/share/nvim/mason/bin
+          mkdir -p ~/.local/share/nvim/mason/packages
+          
+          # Pre-install phpactor manually if possible
+          if [ ! -d ~/.local/share/nvim/mason/packages/phpactor ]; then
+            mkdir -p ~/.local/share/nvim/mason/packages/phpactor
+            git clone --depth 1 https://github.com/phpactor/phpactor ~/.local/share/nvim/mason/packages/phpactor
+            cd ~/.local/share/nvim/mason/packages/phpactor
+            composer install --no-dev -o
+            ln -sf ~/.local/share/nvim/mason/packages/phpactor/bin/phpactor ~/.local/share/nvim/mason/bin/phpactor
+          fi
       - name: Run Tests
         run: make test
       - name: Debugging environment

--- a/tests/clapi/treesitter_spec.lua
+++ b/tests/clapi/treesitter_spec.lua
@@ -4,6 +4,7 @@ local t = require("plenary.async.tests")
 
 local fn = function()
 	require("nvim-treesitter.install").ensure_installed_sync("php")
+	vim.wait(10000)
 	local filename =
 		"/home/markel/estudio/lua/clapi.nvim/tests/clapi/resources/code/php/php-ddd-example/src/Mooc/Courses/Domain/Course.php"
 	vim.cmd("edit " .. filename)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -22,12 +22,25 @@ require("cmp").setup({
 	},
 })
 
-require("mason").setup()
-require("mason-lspconfig").setup({
-	ensure_installed = { "phpactor" },
+require("mason").setup({
+    log_level = vim.log.levels.DEBUG, -- Enable detailed logs for debugging
+    install_root_dir = vim.fn.expand("~/.local/share/nvim/mason"),
 })
 
-require("mason-tool-installer").setup({ ensure_installed = { "phpactor" } })
+-- Log directory information
+vim.notify("Mason install root: " .. vim.fn.expand("~/.local/share/nvim/mason"))
+
+-- Set up Mason-LSPConfig with explicit installation
+require("mason-lspconfig").setup({
+    ensure_installed = { "phpactor" },
+})
+
+-- Force synchronous installation with Mason Tool Installer
+require("mason-tool-installer").setup({ 
+    ensure_installed = { "phpactor" },
+    auto_update = false,
+    run_on_start = true,
+})
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()
 capabilities = vim.tbl_deep_extend("force", capabilities, require("cmp_nvim_lsp").default_capabilities())
@@ -42,5 +55,9 @@ require("mason-lspconfig").setup({
 	},
 })
 
--- NOTE: Had to add this to leave time for the gh action to download the treesitter php parser
-vim.wait(10000)
+-- NOTE: Had to add this to leave time for the gh action to download the treesitter php parser and LSP
+vim.notify("Waiting for treesitter and LSP installation...")
+vim.wait(20000) -- Increased wait time to 20 seconds
+vim.notify("Checking Mason paths and installed servers...")
+vim.api.nvim_exec("!ls -la ~/.local/share/nvim/mason/bin/", true)
+vim.notify("Mason LSP installation paths: " .. vim.inspect(vim.fn.glob("~/.local/share/nvim/mason/packages/*", true, true)))

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -13,6 +13,8 @@ vim.opt.runtimepath:append("~/.local/share/nvim/lazy/cmp-nvim-lsp")
 vim.opt.runtimepath:append("~/.local/share/nvim/lazy/nvim-cmp")
 vim.opt.runtimepath:append("~/.local/share/nvim/lazy/nvim-lspconfig")
 
+require("nvim-treesitter.install").ensure_installed_sync("php")
+
 -- Install parsers
 require("cmp").setup({
 	sources = {
@@ -20,7 +22,6 @@ require("cmp").setup({
 	},
 })
 
-require("nvim-treesitter.install").ensure_installed_sync("php")
 require("mason").setup()
 require("mason-lspconfig").setup({
 	ensure_installed = { "phpactor" },

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -42,4 +42,4 @@ require("mason-lspconfig").setup({
 })
 
 -- NOTE: Had to add this to leave time for the gh action to download the treesitter php parser
--- vim.wait(10000)
+vim.wait(10000)


### PR DESCRIPTION
Tests are failing in the GitHub action because LSP and treesitter parser configurations. The branch was created to be able to push possible fixes without polluting the main branch.

This PR should be squashed merged when fixed